### PR TITLE
Use packr2 to embed sql scripts in binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ RUN mkdir -p /go/src/github.com/asecurityteam/ipam-facade
 WORKDIR $GOPATH/src/github.com/asecurityteam/ipam-facade
 COPY --chown=sdcli:sdcli . .
 RUN sdcli go dep
+RUN go get -u github.com/gobuffalo/packr/v2/packr2
+RUN packr2
 RUN CGO_ENABLED=0 GOOS=linux go build -a -o /opt/app main.go
 
 ##################################


### PR DESCRIPTION
Run `packr2` command before building the binary in the Dockerfile. It looks for all the boxes in the code and generates .go files that pack the static files into bytes that can be bundled into the Go binary. 

See: https://github.com/gobuffalo/packr/tree/master/v2#building-a-binary