### PR TITLE
SECD-745 Stop logging response body

### DIFF
--- a/pkg/ipamfetcher/device42_iterator.go
+++ b/pkg/ipamfetcher/device42_iterator.go
@@ -117,13 +117,13 @@ func (d *Device42PageFetcher) FetchPage(ctx context.Context, offset int, limit i
 	}
 	defer res.Body.Close()
 
+	if res.StatusCode != http.StatusOK {
+		return PagedResponse{}, fmt.Errorf("unexpected error from device42 api: %d", res.StatusCode)
+	}
+
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return PagedResponse{}, err
-	}
-
-	if res.StatusCode != http.StatusOK {
-		return PagedResponse{}, fmt.Errorf("unexpected error from device42 api: %d %s", res.StatusCode, res.Body)
 	}
 
 	var pagedResponse PagedResponse


### PR DESCRIPTION
Removing the response body from the logs, as the value of logging the arbitrary response body is low, and the potential for accidentally logging garbage/PII/secrets/etc. is high.