### PR TITLE
SECD-745 Remove additional logged response body

### DIFF
--- a/pkg/ipamfetcher/customer.go
+++ b/pkg/ipamfetcher/customer.go
@@ -50,13 +50,14 @@ func (d *Device42CustomerFetcher) FetchCustomers(ctx context.Context) ([]domain.
 		return nil, err
 	}
 	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error from device42 api: %d", res.StatusCode)
+	}
+
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
-	}
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected error from device42 api: %d %s", res.StatusCode, res.Body)
 	}
 
 	var getCustomersResponse customersResponse


### PR DESCRIPTION
Removing the logged response body from the Device42 customer client. Missed this in the previous PR.