### PR TITLE
SECD-753 Remove unnecessary fields from Device42 response structs

### DIFF
--- a/pkg/ipamfetcher/customer.go
+++ b/pkg/ipamfetcher/customer.go
@@ -17,23 +17,9 @@ type customersResponse struct {
 }
 
 type customer struct {
-	Contacts     []contact    `json:"Contacts"`
 	CustomFields customFields `json:"Custom Fields"`
 	ContactInfo  string       `json:"contact_info"`
-	DevicesURL   string       `json:"devices_url"`
-	Groups       string       `json:"groups"`
 	ID           int          `json:"id"`
-	Name         string       `json:"name"`
-	Notes        string       `json:"notes"`
-	SubnetsURL   string       `json:"subnets_url"`
-}
-
-type contact struct {
-	Address string `json:"address"`
-	Email   string `json:"email"`
-	Name    string `json:"name"`
-	Phone   string `json:"phone"`
-	Type    string `json:"type"`
 }
 
 // Device42CustomerFetcher fetches customer data from Device42

--- a/pkg/ipamfetcher/device.go
+++ b/pkg/ipamfetcher/device.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"strconv"
-	"time"
 
 	"github.com/asecurityteam/ipam-facade/pkg/domain"
 )
@@ -17,20 +16,9 @@ type ipResponse struct {
 }
 
 type ip struct {
-	Available    string       `json:"available"`
-	CustomFields customFields `json:"custom_fields"`
-	Device       string       `json:"device"`
-	DeviceID     int          `json:"device_id"`
-	ID           int          `json:"id"`
-	IP           string       `json:"ip"`
-	Label        string       `json:"label"`
-	LastUpdated  time.Time    `json:"last_updated"`
-	MacAddress   string       `json:"mac_address"`
-	MacID        int          `json:"mac_id"`
-	Notes        string       `json:"notes"`
-	Subnet       string       `json:"subnet"`
-	SubnetID     int          `json:"subnet_id"`
-	Type         string       `json:"type"`
+	DeviceID int    `json:"device_id"`
+	IP       string `json:"ip"`
+	SubnetID int    `json:"subnet_id"`
 }
 
 // Device42DeviceFetcher implements the DeviceFetcher interface to retrieve device information

--- a/pkg/ipamfetcher/subnet.go
+++ b/pkg/ipamfetcher/subnet.go
@@ -16,32 +16,11 @@ type subnetResponse struct {
 }
 
 type subnet struct {
-	Allocated             string       `json:"allocated"`
-	AllowBroadcastAddress string       `json:"allow_broadcast_address"`
-	AllowNetworkAddress   string       `json:"allow_network_address"`
-	Assigned              string       `json:"assigned"`
-	CanEdit               string       `json:"can_edit"`
-	CategoryID            int          `json:"category_id"`
-	CategoryName          string       `json:"category_name"`
-	CustomFields          customFields `json:"custom_fields"`
-	CustomerID            int          `json:"customer_id"`
-	Description           string       `json:"description"`
-	Gateway               string       `json:"gateway"`
-	MaskBits              int          `json:"mask_bits"`
-	Name                  string       `json:"name"`
-	Network               string       `json:"network"`
-	Notes                 string       `json:"notes"`
-	ParentSubnetID        int          `json:"parent_subnet_id"`
-	ParentVLANID          int          `json:"parent_vlan_id"`
-	ParentVLANName        string       `json:"parent_vlan_name"`
-	ParentVLANNumber      string       `json:"parent_vlan_number"`
-	RangeBegin            string       `json:"range_begin"`
-	RangeEnd              string       `json:"range_end"`
-	ServiceLevel          string       `json:"service_level"`
-	SubnetID              int          `json:"subnet_id"`
-	Tags                  []string     `json:"tags"`
-	VRFGroupID            int          `json:"vrf_group_id"`
-	VRFGroupName          string       `json:"vrf_group_name"`
+	CustomFields customFields `json:"custom_fields"`
+	CustomerID   int          `json:"customer_id"`
+	MaskBits     int          `json:"mask_bits"`
+	Network      string       `json:"network"`
+	SubnetID     int          `json:"subnet_id"`
 }
 
 // Device42SubnetFetcher implements the SubnetFetcher interface to retrieve subnet information


### PR DESCRIPTION
Removing unused fields from the Device42 response structs. For some
fields (such as subnet.parent_vlan_number), the returned values can
be a string or a number, depending on context, which causes unmarshalling
issues. Safer to remove these fields until we need them.