### PR TITLE
add exhausted flag to prevent invalid Current() state

### DIFF
--- a/pkg/ipamfetcher/device42_iterator.go
+++ b/pkg/ipamfetcher/device42_iterator.go
@@ -61,6 +61,7 @@ type Device42PageIterator struct {
 	currentPage PagedResponse
 	offset      int
 	totalCount  int
+	exhausted   bool
 }
 
 // Current returns the current response if there are no issues with the state of the iterator
@@ -68,7 +69,7 @@ func (it *Device42PageIterator) Current() PagedResponse {
 	// Always have a guard against calls to `Current()` after the
 	// iterator is complete. This is technically an invalid call
 	// so "user beware" but this will prevent a panic condition.
-	if it.offset > it.totalCount || it.err != nil {
+	if it.exhausted || it.err != nil {
 		return PagedResponse{}
 	}
 	return it.currentPage
@@ -82,6 +83,7 @@ func (it *Device42PageIterator) Close() error {
 // Next fetches the next page from the API and makes necessary updates to iterator state
 func (it *Device42PageIterator) Next() bool {
 	if it.currentPage.TotalCount > 0 && it.offset >= it.totalCount {
+		it.exhausted = true
 		return false
 	}
 

--- a/pkg/ipamfetcher/device42_iterator_test.go
+++ b/pkg/ipamfetcher/device42_iterator_test.go
@@ -44,8 +44,8 @@ func TestDevice42PageIteratorCurrent(t *testing.T) {
 			expectedResponse: PagedResponse{Offset: 1},
 		},
 		{
-			name:             "offset greater than totalCount",
-			it:               &Device42PageIterator{offset: 11, totalCount: 10, currentPage: PagedResponse{Offset: 10}},
+			name:             "exhausted",
+			it:               &Device42PageIterator{exhausted: true, currentPage: PagedResponse{Offset: 10}},
 			expectedResponse: PagedResponse{},
 		},
 		{
@@ -73,6 +73,7 @@ func TestDevice42PageIteratorNext(t *testing.T) {
 		pageFetchError        error
 		expected              bool
 		expectedOffset        int
+		exhausted             bool
 	}{
 		{
 			name:                  "success",
@@ -103,6 +104,7 @@ func TestDevice42PageIteratorNext(t *testing.T) {
 			pageFetchError:        nil,
 			expected:              false,
 			expectedOffset:        11,
+			exhausted:             true,
 		},
 	}
 
@@ -125,6 +127,7 @@ func TestDevice42PageIteratorNext(t *testing.T) {
 			actual := iterator.Next()
 			assert.Equal(tt, test.expected, actual)
 			assert.Equal(tt, test.expectedOffset, iterator.offset)
+			assert.Equal(tt, test.exhausted, iterator.exhausted)
 		})
 	}
 }


### PR DESCRIPTION
When investigating an issue regarding outgoing requests, I found that the Current() function will return a zero value prematurely. This is due to incrementing the offset at the end of the call to Next(). e.g. for total_count = 150, limit = 100, offset = 0

```
iteration 1:
 - Next() -> fetch first 100. total_count = 150, limit = 100, offset = 100
 - Current() -> offset < total_count, return current_page
iteration 2:
 - Next() -> fetch last 50. total_count = 150, limit = 100, offset = 200
 - Current() -> offset > total_count, return zero value
```

Proposed solution is to add an exhausted flag which gets set when the iterator moves past the last element.