### PR TITLE
account for missing customer id in subnet response

### DIFF
--- a/pkg/ipamfetcher/mock_logger_test.go
+++ b/pkg/ipamfetcher/mock_logger_test.go
@@ -1,0 +1,20 @@
+package ipamfetcher
+
+import (
+	"context"
+
+	"github.com/asecurityteam/ipam-facade/pkg/domain"
+)
+
+type nopLogger struct{}
+
+func (*nopLogger) Debug(event interface{})                 {}
+func (*nopLogger) Info(event interface{})                  {}
+func (*nopLogger) Warn(event interface{})                  {}
+func (*nopLogger) Error(event interface{})                 {}
+func (*nopLogger) SetField(name string, value interface{}) {}
+func (logger *nopLogger) Copy() domain.Logger {
+	return logger
+}
+
+func testLogFn(context.Context) domain.Logger { return &nopLogger{} }

--- a/pkg/ipamfetcher/subnet.go
+++ b/pkg/ipamfetcher/subnet.go
@@ -49,7 +49,7 @@ func (d *Device42SubnetFetcher) FetchSubnets(ctx context.Context) ([]domain.Subn
 		}
 		for _, subnet := range subnetsResponse.Subnets {
 			if subnet.CustomerID == 0 {
-				// CustomID is required as a FK in the datastore. If missing, log and move on.
+				// CustomerID is required as a FK in the datastore. If missing, log and move on.
 				d.LogFn(ctx).Info(logs.InvalidSubnet{
 					ID:     subnet.SubnetID,
 					Reason: "Missing customer ID in subnet",

--- a/pkg/ipamfetcher/subnet.go
+++ b/pkg/ipamfetcher/subnet.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/asecurityteam/ipam-facade/pkg/domain"
+	"github.com/asecurityteam/ipam-facade/pkg/logs"
 )
 
 type subnetResponse struct {
@@ -28,6 +29,7 @@ type subnet struct {
 type Device42SubnetFetcher struct {
 	PageFetcher PageFetcher
 	Limit       int
+	LogFn       domain.LogFn
 }
 
 // FetchSubnets retrieves subnet information from Device42
@@ -46,6 +48,14 @@ func (d *Device42SubnetFetcher) FetchSubnets(ctx context.Context) ([]domain.Subn
 			return nil, err
 		}
 		for _, subnet := range subnetsResponse.Subnets {
+			if subnet.CustomerID == 0 {
+				// CustomID is required as a FK in the datastore. If missing, log and move on.
+				d.LogFn(ctx).Info(logs.InvalidSubnet{
+					ID:     subnet.SubnetID,
+					Reason: "Missing customer ID in subnet",
+				})
+				continue
+			}
 			subnets = append(subnets, domain.Subnet{
 				ID:         strconv.Itoa(subnet.SubnetID),
 				Network:    subnet.Network,

--- a/pkg/ipamfetcher/subnet_test.go
+++ b/pkg/ipamfetcher/subnet_test.go
@@ -48,6 +48,28 @@ func TestFetchSubnetsMultiple(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestFetchSubnetsMissingCustomerID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockPageFetcher := NewMockPageFetcher(ctrl)
+	mockPageFetcher.EXPECT().FetchPage(gomock.Any(), 0, 1).Return(PagedResponse{TotalCount: 3, Offset: 0, Body: []byte(`{"offset": 0, "limit": 1, "total_count": 3, "subnets": [{"subnet_id": 1, "network": "192.168.1.1", "mask_bits": 32, "custom_fields": [{"key": "Location", "value": "AUS"}], "customer_id": 1}]}`)}, nil)
+	mockPageFetcher.EXPECT().FetchPage(gomock.Any(), 1, 1).Return(PagedResponse{TotalCount: 3, Offset: 1, Body: []byte(`{"offset": 1, "limit": 1, "total_count": 3, "subnets": [{"subnet_id": 2, "network": "192.168.1.0", "mask_bits": 28, "custom_fields": [{"key": "Location", "value": "SYD"}], "customer_id": 2}]}`)}, nil)
+	mockPageFetcher.EXPECT().FetchPage(gomock.Any(), 2, 1).Return(PagedResponse{TotalCount: 3, Offset: 2, Body: []byte(`{"offset": 2, "limit": 1, "total_count": 3, "subnets": [{"subnet_id": 3, "network": "192.168.1.3", "mask_bits": 32, "custom_fields": [{"key": "Location", "value": "LON"}], "customer_id": 0}]}`)}, nil)
+
+	d := &Device42SubnetFetcher{
+		Limit:       1,
+		PageFetcher: mockPageFetcher,
+		LogFn:       testLogFn,
+	}
+
+	subnets, err := d.FetchSubnets(context.Background())
+	assert.ElementsMatch(t, []domain.Subnet{
+		domain.Subnet{ID: "1", Network: "192.168.1.1", MaskBits: int8(32), Location: "AUS", CustomerID: "1"},
+		domain.Subnet{ID: "2", Network: "192.168.1.0", MaskBits: int8(28), Location: "SYD", CustomerID: "2"},
+	}, subnets)
+	assert.Nil(t, err)
+}
+
 func TestFetchSubnetsUnmarshalError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/logs/info.go
+++ b/pkg/logs/info.go
@@ -1,0 +1,8 @@
+package logs
+
+// InvalidSubnet is logged when a Subnet is returned from Device42 which is invalid or incomplete
+type InvalidSubnet struct {
+	Message string `logevent:"message,default=invalid-subnet"`
+	ID      int    `logevent:"id"`
+	Reason  string `logevent:"reason"`
+}


### PR DESCRIPTION
Was seeing a number of FK constraint violations when attempting to sync the IPAM cache:

`{"errorMessage":"pq: insert or update on table \"subnets\" violates foreign key constraint \"subnets_customer_id_fkey\"","errorType":"Error","stackTrace":[]}`

Spoke with @faldridge and decided to log the event, and skip over that subnet.