### PR TITLE
One to many

### DIFF
--- a/pkg/assetfetcher/postgres.go
+++ b/pkg/assetfetcher/postgres.go
@@ -7,17 +7,17 @@ import (
 	"github.com/asecurityteam/ipam-facade/pkg/domain"
 )
 
-const fetchByIPQuery = `SELECT host(d.ip) as ip, c.resource_owner as resource_owner,
+const fetchByIPQuery = `SELECT host(i.ip) as ip, c.resource_owner as resource_owner,
 							c.business_unit as business_unit, text(s.network) as network,
-							s.location as location, d.id as device_id, s.id as subnet_id,
+							s.location as location, device_id, s.id as subnet_id,
 							c.id as customer_id
-			            FROM devices d
+			            FROM ips i
 					  	RIGHT OUTER JOIN subnets s ON
-					  		d.subnet_id = s.id
-				  		AND d.ip = $1
+					  		i.subnet_id = s.id
+						AND i.ip = $1
 						INNER JOIN customers c ON s.customer_id = c.id
 						WHERE s.network >>= $1
-						ORDER BY d.id IS NOT NULL DESC, masklen(s.network) DESC
+						ORDER BY i.device_id IS NOT NULL DESC, masklen(s.network) DESC
 						LIMIT 1;`
 
 // PostgresPhysicalAssetFetcher physical assets from a PostgreSQL database by IP address.

--- a/pkg/assetstorer/postgres.go
+++ b/pkg/assetstorer/postgres.go
@@ -11,7 +11,7 @@ import (
 const (
 	insertCustomerStatement = `INSERT INTO customers VALUES ($1, $2, $3)`
 	insertSubnetStatement   = `INSERT INTO subnets VALUES ($1, $2, $3, $4)`
-	insertIPStatement       = `INSERT INTO ips VALUES ($1, $2, $3)`
+	insertIPStatement       = `INSERT INTO ips VALUES (DEFAULT, $1, $2, $3)`
 )
 
 // PostgresPhysicalAssetStorer stores physical assets in a PostgreSQL database.
@@ -75,7 +75,11 @@ func (s *PostgresPhysicalAssetStorer) storeSubnet(ctx context.Context, subnet do
 }
 
 func (s *PostgresPhysicalAssetStorer) storeIP(ctx context.Context, device domain.Device, tx *sql.Tx) error {
-	if _, err := tx.ExecContext(ctx, insertIPStatement, device.IP, device.SubnetID, device.ID); err != nil {
+	var deviceID *string
+	if device.ID != "" {
+		deviceID = &device.ID
+	}
+	if _, err := tx.ExecContext(ctx, insertIPStatement, device.IP, device.SubnetID, deviceID); err != nil {
 		return err
 	}
 

--- a/pkg/assetstorer/postgres.go
+++ b/pkg/assetstorer/postgres.go
@@ -11,7 +11,7 @@ import (
 const (
 	insertCustomerStatement = `INSERT INTO customers VALUES ($1, $2, $3)`
 	insertSubnetStatement   = `INSERT INTO subnets VALUES ($1, $2, $3, $4)`
-	insertDeviceStatement   = `INSERT INTO devices VALUES ($1, $2, $3)`
+	insertIPStatement       = `INSERT INTO ips VALUES ($1, $2, $3)`
 )
 
 // PostgresPhysicalAssetStorer stores physical assets in a PostgreSQL database.
@@ -50,7 +50,7 @@ func (s *PostgresPhysicalAssetStorer) savePhysicalAssets(ctx context.Context, ip
 	}
 
 	for _, device := range ipamData.Devices {
-		if err := s.storeDevice(ctx, device, tx); err != nil {
+		if err := s.storeIP(ctx, device, tx); err != nil {
 			return err
 		}
 	}
@@ -74,8 +74,8 @@ func (s *PostgresPhysicalAssetStorer) storeSubnet(ctx context.Context, subnet do
 	return nil
 }
 
-func (s *PostgresPhysicalAssetStorer) storeDevice(ctx context.Context, device domain.Device, tx *sql.Tx) error {
-	if _, err := tx.ExecContext(ctx, insertDeviceStatement, device.ID, device.IP, device.SubnetID); err != nil {
+func (s *PostgresPhysicalAssetStorer) storeIP(ctx context.Context, device domain.Device, tx *sql.Tx) error {
+	if _, err := tx.ExecContext(ctx, insertIPStatement, device.IP, device.SubnetID, device.ID); err != nil {
 		return err
 	}
 

--- a/pkg/ipamfetcher/device_test.go
+++ b/pkg/ipamfetcher/device_test.go
@@ -44,6 +44,24 @@ func TestFetchDevicesMultiple(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestFetchDevicesMultipleSameDevice(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockPageFetcher := NewMockPageFetcher(ctrl)
+	mockPageFetcher.EXPECT().FetchPage(gomock.Any(), 0, 1).Return(PagedResponse{TotalCount: 3, Offset: 0, Body: []byte(`{"offset": 0, "limit": 1, "total_count": 3, "ips": [{"ip": "192.168.1.1", "device_id": 1, "subnet_id": 1}]}`)}, nil)
+	mockPageFetcher.EXPECT().FetchPage(gomock.Any(), 1, 1).Return(PagedResponse{TotalCount: 3, Offset: 1, Body: []byte(`{"offset": 1, "limit": 1, "total_count": 3, "ips": [{"ip": "192.168.1.2", "device_id": 1, "subnet_id": 2}]}`)}, nil)
+	mockPageFetcher.EXPECT().FetchPage(gomock.Any(), 2, 1).Return(PagedResponse{TotalCount: 3, Offset: 2, Body: []byte(`{"offset": 2, "limit": 1, "total_count": 3, "ips": [{"ip": "192.168.1.3", "device_id": 1, "subnet_id": 3}]}`)}, nil)
+
+	d := &Device42DeviceFetcher{
+		Limit:       1,
+		PageFetcher: mockPageFetcher,
+	}
+
+	assets, err := d.FetchDevices(context.Background())
+	assert.ElementsMatch(t, []domain.Device{domain.Device{IP: "192.168.1.1", ID: "1", SubnetID: "1"}, domain.Device{IP: "192.168.1.2", ID: "1", SubnetID: "2"}, domain.Device{IP: "192.168.1.3", ID: "1", SubnetID: "3"}}, assets)
+	assert.Nil(t, err)
+}
+
 func TestFetchDevicesUnmarshalError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/scripts/2_create.sql
+++ b/scripts/2_create.sql
@@ -17,10 +17,11 @@ IF NOT EXISTS subnets
 );
 
 CREATE TABLE
-IF NOT EXISTS devices
+IF NOT EXISTS ips
 (
-    id INTEGER PRIMARY KEY,
+    PRIMARY KEY (ip, device_id),
     ip INET,
     subnet_id INTEGER NOT NULL,
-    FOREIGN KEY (subnet_id) REFERENCES subnets (id) ON DELETE CASCADE
+    FOREIGN KEY (subnet_id) REFERENCES subnets (id) ON DELETE CASCADE,
+    device_id INTEGER NOT NULL
 );

--- a/scripts/2_create.sql
+++ b/scripts/2_create.sql
@@ -19,9 +19,9 @@ IF NOT EXISTS subnets
 CREATE TABLE
 IF NOT EXISTS ips
 (
-    PRIMARY KEY (ip, device_id),
-    ip INET,
+    id SERIAL PRIMARY KEY,
+    ip INET NOT NULL,
     subnet_id INTEGER NOT NULL,
     FOREIGN KEY (subnet_id) REFERENCES subnets (id) ON DELETE CASCADE,
-    device_id INTEGER NOT NULL
+    device_id INTEGER
 );


### PR DESCRIPTION
Turns out IPAM may return multiple device array objects with the same IP address.  Given the relationship is one-to-many, not one-to-one as had originally been coded, we need to refactor a bit of SQL and code to handle the relationships.

During review, if you have a sharp eye, you'll see I'm just using an auto incremented primary key in the `ips` table.  We tend to not like auto-incremented keys, but the intent of this service is to be short-lived, and the db tables get wiped between triggered runs anyway.  So 🤷‍♂ .