### PR TITLE
clear tables upon receiving sync request

### DIFF
--- a/pkg/assetstorer/postgres_test.go
+++ b/pkg/assetstorer/postgres_test.go
@@ -47,6 +47,9 @@ func TestPostgresPhysicalAssetStorer_StorePhysicalAssets_Success(t *testing.T) {
 	}
 
 	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM customers").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM subnets").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM ips").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("INSERT INTO customers").WithArgs(customer.ID, customer.ResourceOwner, customer.BusinessUnit).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO subnets").WithArgs(subnet.ID, subnet.Network, subnet.Location, subnet.CustomerID).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO ips").WithArgs(device.IP, device.SubnetID, device.ID).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -95,6 +98,9 @@ func TestPostgresPhysicalAssetStorer_StorePhysicalAssetsNoDeviceID_Success(t *te
 	}
 
 	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM customers").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM subnets").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM ips").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("INSERT INTO customers").WithArgs(customer.ID, customer.ResourceOwner, customer.BusinessUnit).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO subnets").WithArgs(subnet.ID, subnet.Network, subnet.Location, subnet.CustomerID).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO ips").WithArgs(device.IP, device.SubnetID, nil).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -129,6 +135,9 @@ func TestPostgresPhysicalAssetStorer_StorePhysicalAssetsNoCustomerID_Success(t *
 	}
 
 	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM customers").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM subnets").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM ips").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("INSERT INTO subnets").WithArgs(subnet.ID, subnet.Network, subnet.Location, sql.NullString{}).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
@@ -173,6 +182,9 @@ func TestPostgresPhysicalAssetStorer_StorePhysicalAssets_RollbackError(t *testin
 	}
 
 	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM customers").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM subnets").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM ips").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("INSERT INTO customers").WithArgs(customer.ID, customer.ResourceOwner, customer.BusinessUnit).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO subnets").WithArgs(subnet.ID, subnet.Network, subnet.Location, subnet.CustomerID).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO ips").WithArgs(device.IP, device.SubnetID, device.ID).WillReturnError(fmt.Errorf("some error"))
@@ -223,6 +235,9 @@ func TestPostgresPhysicalAssetStorer_storeSubnet_Error(t *testing.T) {
 	}
 
 	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM customers").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM subnets").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM ips").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("INSERT INTO subnets").WithArgs(subnet.ID, subnet.Network, subnet.Location, subnet.CustomerID).WillReturnError(fmt.Errorf("some error"))
 	mock.ExpectRollback()
 
@@ -253,6 +268,9 @@ func TestPostgresPhysicalAssetStorer_storeCustomer_Error(t *testing.T) {
 	}
 
 	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM customers").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM subnets").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM ips").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("INSERT INTO customers").WithArgs(customer.ID, customer.ResourceOwner, customer.BusinessUnit).WillReturnError(fmt.Errorf("some error"))
 	mock.ExpectRollback()
 
@@ -282,6 +300,9 @@ func TestPostgresPhysicalAssetStorer_storeIP_Error(t *testing.T) {
 	}
 
 	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM customers").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM subnets").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM ips").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("INSERT INTO ips").WithArgs(device.IP, device.SubnetID, device.ID).WillReturnError(fmt.Errorf("some error"))
 	mock.ExpectRollback()
 


### PR DESCRIPTION
The POST to /sync is _supposed_ to clear the tables in the transaction that refreshes the data across all the tables.