### PR TITLE
PANG-1536: Update Makefile to use docker compose V2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: go
-sudo: false
 go:
   - 1.12.x
 services:
   - docker
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -v -L "https://github.com/docker/compose/releases/download/v2.11.2/docker-compose-linux-x86_64" -o docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
 install:
   - chmod 777 -R "$(pwd)"
 script:

--- a/Makefile
+++ b/Makefile
@@ -3,24 +3,23 @@ DIR := $(shell pwd -L)
 
 dep:
 	docker run -ti \
-        --mount src="$(DIR)",target="$(DIR)",type="bind" \
+        -v "$(DIR):$(DIR)" \
         -w "$(DIR)" \
         asecurityteam/sdcli:v1 go dep
 
 lint:
 	docker run -ti \
-        --mount src="$(DIR)",target="$(DIR)",type="bind" \
+        -v "$(DIR):$(DIR)" \
         -w "$(DIR)" \
         asecurityteam/sdcli:v1 go lint
 
 test:
 	docker run -ti \
-        --mount src="$(DIR)",target="$(DIR)",type="bind" \
+        -v "$(DIR):$(DIR)" \
         -w "$(DIR)" \
         asecurityteam/sdcli:v1 go test
 
 integration:
-	DIR=$(DIR) \
 	DIR=$(DIR) \
 	docker-compose \
 		-f docker-compose.it.yaml \
@@ -31,7 +30,7 @@ integration:
 
 coverage:
 	docker run -ti \
-        --mount src="$(DIR)",target="$(DIR)",type="bind" \
+        -v "$(DIR):$(DIR)" \
         -w "$(DIR)" \
         asecurityteam/sdcli:v1 go coverage
 

--- a/pkg/domain/doc.go
+++ b/pkg/domain/doc.go
@@ -12,5 +12,4 @@
 // define a corresponding Error() method. Because these errors provide executable
 // code they must also have corresponding tests. Only domain error types are allowed
 // to deviate from the "no executable code" rule.
-//
 package domain

--- a/tests/postgres_test.go
+++ b/tests/postgres_test.go
@@ -1,4 +1,5 @@
-//+build integration
+//go:build integration
+// +build integration
 
 package inttest
 


### PR DESCRIPTION
With the recent changes to [SDCLI](https://github.com/asecurityteam/sdcli/pull/69) to use Docker Compose V2 under the hood, our internal services are being updated to stay compatible.

Adds some `gofmt` fixes to comply with CI.